### PR TITLE
Fix container trying to listen on IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY overlay/ /
 
 EXPOSE 443
 
-ENTRYPOINT [ "sniproxy", "-f" ]
+CMD [ "sniproxy", "-f", "-c", "/etc/sniproxy.conf" ]

--- a/overlay/etc/sniproxy.conf
+++ b/overlay/etc/sniproxy.conf
@@ -16,7 +16,7 @@ error_log {
 	filename /dev/stderr
 }
 
-listener 443 {
+listener 0.0.0.0:443 {
 	protocol tls
 }
 


### PR DESCRIPTION
@mintopia to review:

The image now binds to 0.0.0.0:443 instead of :443 which included IPv6, This was the original behaviour before commit a0eed8f (84d2a82)
I have also changed the Dockerfile to use CMD instead of Entrypoint which allows running direct to sh if we need to. (a9dd151)

This will resolve issue #6 