### PR TITLE
update http links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Documentation
 
-The documentation for the LanCache.net project can be found on [our website](http://www.lancache.net)
+The documentation for the LanCache.net project can be found on [our website](https://lancache.net)
 
-The specific documentation for this sniproxy container is [here](http://lancache.net/docs/containers/sniproxy/)
+The specific documentation for this sniproxy container is [here](https://lancache.net/docs/containers/sniproxy/)
 
-If you have any problems after reading the documentation please see [the support page](http://lancache.net/support/) before opening a new issue on github.
+If you have any problems after reading the documentation please see [the support page](https://lancache.net/support/) before opening a new issue on github.
 
 ## Thanks
 


### PR DESCRIPTION
this domain (lancache.net) supports https, so there's no reason not to use that.